### PR TITLE
Add function to trigger events for multiple contacts

### DIFF
--- a/lib/emarsys/data_objects/event.rb
+++ b/lib/emarsys/data_objects/event.rb
@@ -33,6 +33,22 @@ module Emarsys
         post "event/#{event_id}/trigger", params
       end
 
+      # Trigger an external event for multiple contacts
+      #
+      # @param event_id [Integer, String] The internal emarsys id
+      # @param key_id [Integer, String] The identifer of the key field (e.g. 3 for 'email')
+      # @param contacts [Array, Hash] An array with hashes containing the contacts and optional data per contact
+      # @return [Hash] Result data
+      # @example
+      #   Emarsys::Event.trigger_multiple(2, 3, [{:external_id => "test@example.com"},{:external_id => "test2@example.com", :data => {:name => "Special Name"}}])
+      def trigger_multiple(event_id, key_id, contacts)
+        external_id = ""
+        transformed_key_id = transform_key_id(key_id)
+        params = {:key_id => transformed_key_id, :external_id => external_id, :data => nil}
+        params.merge!(:contacts => contacts)
+        post "event/#{event_id}/trigger", params
+      end
+
       # @private
       def transform_key_id(key_id)
         matching_attributes = Emarsys::FieldMapping::ATTRIBUTES.find{|elem| elem[:identifier] == key_id.to_s}

--- a/spec/emarsys/data_objects/event_spec.rb
+++ b/spec/emarsys/data_objects/event_spec.rb
@@ -20,4 +20,12 @@ describe Emarsys::Event do
       stub.should have_been_requested.once
     end
   end
+
+  describe ".trigger_multiple" do
+    it "requests event trigger with parameters" do
+      stub = stub_request(:post, "https://suite5.emarsys.net/api/v2/event/123/trigger").with(:body => {'key_id' => 3, 'external_id' => "", :data => nil, :contacts => [{'external_id' => "jane.doe@example.com"}]}.to_json).to_return(standard_return_body)
+      Emarsys::Event.trigger_multiple(123,3,[{'external_id' => 'jane.doe@example.com'}])
+      stub.should have_been_requested.once
+    end
+  end
 end


### PR DESCRIPTION
We have been missing the ability in the gem to trigger events for multiple contacts in one call.

I've added a new function for this since the parameters necessary differs from the normal event-trigger call.

Emarsys documentation: http://documentation.emarsys.com/resource/developers/endpoints/external-events/triggering-multiple-events/