### PR TITLE
Use random byte nonce for WSSE header instead of hashed time

### DIFF
--- a/lib/emarsys/client.rb
+++ b/lib/emarsys/client.rb
@@ -25,7 +25,8 @@ module Emarsys
     end
 
     def header_nonce
-      Digest::MD5.hexdigest(header_created)
+      bytes = Random::DEFAULT.bytes(16)
+      bytes.each_byte.map { |b| sprintf("%02X",b) }.join
     end
 
     def header_created

--- a/spec/emarsys/client_spec.rb
+++ b/spec/emarsys/client_spec.rb
@@ -54,9 +54,8 @@ describe Emarsys::Client do
     end
 
     describe '#header_nonce' do
-      it 'uses md5 hash auf current time (as integer)' do
-        Digest::MD5.should_receive(:hexdigest).with(Time.now.utc.iso8601).and_return("25f9e794323b453885f5181f1b624d0b")
-        Emarsys::Client.new.header_nonce
+      it 'uses 16 random bytes to generate a 32 char hex string' do
+        expect(Emarsys::Client.new.header_nonce).to match(/^[0-9a-f]{32}$/i)
       end
     end
 


### PR DESCRIPTION
Avoids nonce reuse, if several requests are generated in the same second.