### PR TITLE
Default to unspecific API endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ Authenticate with the api credentials provided by your Emarsys account manager.
 Emarsys.configure do |c|
   c.api_username = 'my_username'
   c.api_password = 'my_password'
-  # OPTIONAL, defaults to https://suite5.emarsys.net/api/v2
-  c.api_endpoint = 'https://www.emarsys.net/api/v2'
+  # OPTIONAL, defaults to https://api.emarsys.net/api/v2
+  c.api_endpoint = 'https://suite5.emarsys.net/api/v2'
 end
 ```
 

--- a/lib/emarsys.rb
+++ b/lib/emarsys.rb
@@ -36,7 +36,7 @@ module Emarsys
   class << self
 
     # @!attribute api_endpoint
-    #   @return [String] Base URL for emarsys URLs. default: https://suite5.emarsys.net/api/v2
+    #   @return [String] Base URL for emarsys URLs. default: https://api.emarsys.net/api/v2
     # @!attribute api_password
     #   @return [String] API Username given by Emarsys
     # @!attribute api_username
@@ -48,7 +48,7 @@ module Emarsys
     #
     # @return [String] domain which should be used to query the API
     def api_endpoint
-      @api_endpoint ||= 'https://suite5.emarsys.net/api/v2'
+      @api_endpoint ||= 'https://api.emarsys.net/api/v2'
     end
 
     # Set configuration options using a block

--- a/spec/emarsys/data_objects/contact_spec.rb
+++ b/spec/emarsys/data_objects/contact_spec.rb
@@ -4,7 +4,7 @@ describe Emarsys::Contact do
   describe ".create" do
     it "requests contact creation with parameters" do
       stub_params = {1 => 'John', 2 => "Doe"}
-      stub = stub_request(:post, "https://suite5.emarsys.net/api/v2/contact").with(:body => stub_params.merge!({'key_id' => 3, 3 => 'john.doe@example.com'}).to_json).to_return(standard_return_body)
+      stub = stub_request(:post, "https://api.emarsys.net/api/v2/contact").with(:body => stub_params.merge!({'key_id' => 3, 3 => 'john.doe@example.com'}).to_json).to_return(standard_return_body)
       Emarsys::Contact.create(3, "john.doe@example.com", stub_params)
       stub.should have_been_requested.once
     end
@@ -12,7 +12,7 @@ describe Emarsys::Contact do
 
   describe ".emarsys_id" do
     it "requests emarsys_id of a contact" do
-      stub = stub_request(:get, "https://suite5.emarsys.net/api/v2/contact/3=jane.doe@example.com").to_return(standard_return_body)
+      stub = stub_request(:get, "https://api.emarsys.net/api/v2/contact/3=jane.doe@example.com").to_return(standard_return_body)
       Emarsys::Contact.emarsys_id(3, 'jane.doe@example.com')
       stub.should have_been_requested.once
     end
@@ -21,7 +21,7 @@ describe Emarsys::Contact do
   describe ".update" do
     it "requests contact update with parameters" do
       stub_params = {1 => 'Jane', 2 => "Doe"}
-      stub = stub_request(:put, "https://suite5.emarsys.net/api/v2/contact").with(:body => stub_params.merge!({'key_id' => 3, 3 => 'jane.doe@example.com'}).to_json).to_return(standard_return_body)
+      stub = stub_request(:put, "https://api.emarsys.net/api/v2/contact").with(:body => stub_params.merge!({'key_id' => 3, 3 => 'jane.doe@example.com'}).to_json).to_return(standard_return_body)
       Emarsys::Contact.update(3, 'jane.doe@example.com', stub_params)
       stub.should have_been_requested.once
     end
@@ -30,7 +30,7 @@ describe Emarsys::Contact do
   describe ".create_batch" do
     it "requests contact batch creation with parameters" do
       stub_params = [{1 => 'Jane', 2 => "Doe"}, {1 => 'Paul', 2 => 'Tester'}]
-      stub = stub_request(:post, "https://suite5.emarsys.net/api/v2/contact").with(:body => {'key_id' => 3, 'contacts' => stub_params}.to_json).to_return(standard_return_body)
+      stub = stub_request(:post, "https://api.emarsys.net/api/v2/contact").with(:body => {'key_id' => 3, 'contacts' => stub_params}.to_json).to_return(standard_return_body)
       Emarsys::Contact.create_batch(3, stub_params)
       stub.should have_been_requested.once
     end
@@ -39,7 +39,7 @@ describe Emarsys::Contact do
   describe ".update_batch" do
     it "requests contact batch update with parameters" do
       stub_params = [{1 => 'Jane', 2 => "Doe"}, {1 => 'Paul', 2 => 'Tester'}]
-      stub = stub_request(:put, "https://suite5.emarsys.net/api/v2/contact").with(:body => {'key_id' => 3, 'contacts' => stub_params}.to_json).to_return(standard_return_body)
+      stub = stub_request(:put, "https://api.emarsys.net/api/v2/contact").with(:body => {'key_id' => 3, 'contacts' => stub_params}.to_json).to_return(standard_return_body)
       Emarsys::Contact.update_batch(3, stub_params)
       stub.should have_been_requested.once
     end
@@ -48,7 +48,7 @@ describe Emarsys::Contact do
   describe ".contact_history" do
     it "requests contact histories" do
       stub_params = [1,2,3]
-      stub = stub_request(:post, "https://suite5.emarsys.net/api/v2/contact/getcontacthistory").with(:body => {'contacts' => stub_params}.to_json).to_return(standard_return_body)
+      stub = stub_request(:post, "https://api.emarsys.net/api/v2/contact/getcontacthistory").with(:body => {'contacts' => stub_params}.to_json).to_return(standard_return_body)
       Emarsys::Contact.contact_history(stub_params)
       stub.should have_been_requested.once
     end
@@ -56,7 +56,7 @@ describe Emarsys::Contact do
 
   describe ".search" do
     it "requests contact data based on search params" do
-      stub = stub_request(:post, "https://suite5.emarsys.net/api/v2/contact/getdata").with(:body => {'keyId' => '3', 'keyValues' => ['jane.doe@example.com'], 'fields' => []}.to_json).to_return(standard_return_body)
+      stub = stub_request(:post, "https://api.emarsys.net/api/v2/contact/getdata").with(:body => {'keyId' => '3', 'keyValues' => ['jane.doe@example.com'], 'fields' => []}.to_json).to_return(standard_return_body)
       Emarsys::Contact.search('3', ['jane.doe@example.com'])
       stub.should have_been_requested.once
     end
@@ -65,7 +65,7 @@ describe Emarsys::Contact do
   describe ".export_registrations" do
     it "requests contact data export based on parameters" do
       stub_params = {distribution_method: 'local', time_range: ["2013-01-01","2013-12-31"], contact_fields: [1,2,3]}
-      stub = stub_request(:post, "https://suite5.emarsys.net/api/v2/contact/getregistrations").with(:body => stub_params.to_json).to_return(standard_return_body)
+      stub = stub_request(:post, "https://api.emarsys.net/api/v2/contact/getregistrations").with(:body => stub_params.to_json).to_return(standard_return_body)
       Emarsys::Contact.export_registrations(stub_params)
       stub.should have_been_requested.once
     end

--- a/spec/emarsys/data_objects/email_spec.rb
+++ b/spec/emarsys/data_objects/email_spec.rb
@@ -27,14 +27,14 @@ describe Emarsys::Email do
 
   describe ".create" do
     it "requests email creation" do
-      stub = stub_request(:post, "https://suite5.emarsys.net/api/v2/email").to_return(standard_return_body)
+      stub = stub_request(:post, "https://api.emarsys.net/api/v2/email").to_return(standard_return_body)
       Emarsys::Email.create
       stub.should have_been_requested.once
     end
 
     it "requests email creation with parameters" do
       stub_params = {:language => 'de', :name => "Something"}
-      stub = stub_request(:post, "https://suite5.emarsys.net/api/v2/email").with(:body => stub_params.to_json).to_return(standard_return_body)
+      stub = stub_request(:post, "https://api.emarsys.net/api/v2/email").with(:body => stub_params.to_json).to_return(standard_return_body)
       Emarsys::Email.create(stub_params)
       stub.should have_been_requested.once
     end
@@ -42,14 +42,14 @@ describe Emarsys::Email do
 
   describe ".launch" do
     it "requests an email launch" do
-      stub = stub_request(:post, "https://suite5.emarsys.net/api/v2/email/123/launch").to_return(standard_return_body)
+      stub = stub_request(:post, "https://api.emarsys.net/api/v2/email/123/launch").to_return(standard_return_body)
       Emarsys::Email.launch(123)
       stub.should have_been_requested.once
     end
 
     it "requests an email launch with parameters" do
       stub_params = {:schedule => "2013-12-01 23:00:00", :time_zone => "Europe/Berlin"}
-      stub = stub_request(:post, "https://suite5.emarsys.net/api/v2/email/123/launch").with(:body => stub_params.to_json).to_return(standard_return_body)
+      stub = stub_request(:post, "https://api.emarsys.net/api/v2/email/123/launch").with(:body => stub_params.to_json).to_return(standard_return_body)
       Emarsys::Email.launch(123, stub_params)
       stub.should have_been_requested.once
     end
@@ -58,7 +58,7 @@ describe Emarsys::Email do
   describe ".preview" do
     it "requests an email preview" do
       stub_params = {:version => 'html'}
-      stub = stub_request(:post, "https://suite5.emarsys.net/api/v2/email/123/preview").with(:body => stub_params.to_json).to_return(standard_return_body)
+      stub = stub_request(:post, "https://api.emarsys.net/api/v2/email/123/preview").with(:body => stub_params.to_json).to_return(standard_return_body)
       Emarsys::Email.preview(123, 'html')
       stub.should have_been_requested.once
     end
@@ -67,7 +67,7 @@ describe Emarsys::Email do
   describe ".send_test_mail" do
     it "requests an email test sending with custom recipient list" do
       stub_params = {:recipientlist => 'john.doe@example.com;jane.doe@example.com'}
-      stub = stub_request(:post, "https://suite5.emarsys.net/api/v2/email/123/sendtestmail").with(:body => stub_params.to_json).to_return(standard_return_body)
+      stub = stub_request(:post, "https://api.emarsys.net/api/v2/email/123/sendtestmail").with(:body => stub_params.to_json).to_return(standard_return_body)
       Emarsys::Email.send_test_mail(123, stub_params)
       stub.should have_been_requested.once
     end

--- a/spec/emarsys/data_objects/event_spec.rb
+++ b/spec/emarsys/data_objects/event_spec.rb
@@ -9,13 +9,13 @@ describe Emarsys::Event do
 
   describe ".trigger" do
     it "requests event trigger with parameters" do
-      stub = stub_request(:post, "https://suite5.emarsys.net/api/v2/event/123/trigger").with(:body => {'key_id' => 3, 'external_id' => "jane.doe@example.com"}.to_json).to_return(standard_return_body)
+      stub = stub_request(:post, "https://api.emarsys.net/api/v2/event/123/trigger").with(:body => {'key_id' => 3, 'external_id' => "jane.doe@example.com"}.to_json).to_return(standard_return_body)
       Emarsys::Event.trigger(123, 3, 'jane.doe@example.com')
       stub.should have_been_requested.once
     end
 
     it "requests event trigger with additional data parameters" do
-      stub = stub_request(:post, "https://suite5.emarsys.net/api/v2/event/123/trigger").with(:body => {'key_id' => 3, 'external_id' => "jane.doe@example.com", :data => {'global' => {'my_placeholder' => 'Something'}}}.to_json).to_return(standard_return_body)
+      stub = stub_request(:post, "https://api.emarsys.net/api/v2/event/123/trigger").with(:body => {'key_id' => 3, 'external_id' => "jane.doe@example.com", :data => {'global' => {'my_placeholder' => 'Something'}}}.to_json).to_return(standard_return_body)
       Emarsys::Event.trigger(123, 3, 'jane.doe@example.com', {'global' => {'my_placeholder' => 'Something'}})
       stub.should have_been_requested.once
     end
@@ -23,7 +23,7 @@ describe Emarsys::Event do
 
   describe ".trigger_multiple" do
     it "requests event trigger with parameters" do
-      stub = stub_request(:post, "https://suite5.emarsys.net/api/v2/event/123/trigger").with(:body => {'key_id' => 3, 'external_id' => "", :data => nil, :contacts => [{'external_id' => "jane.doe@example.com"}]}.to_json).to_return(standard_return_body)
+      stub = stub_request(:post, "https://api.emarsys.net/api/v2/event/123/trigger").with(:body => {'key_id' => 3, 'external_id' => "", :data => nil, :contacts => [{'external_id' => "jane.doe@example.com"}]}.to_json).to_return(standard_return_body)
       Emarsys::Event.trigger_multiple(123,3,[{'external_id' => 'jane.doe@example.com'}])
       stub.should have_been_requested.once
     end

--- a/spec/emarsys/data_objects/file_spec.rb
+++ b/spec/emarsys/data_objects/file_spec.rb
@@ -14,14 +14,14 @@ describe Emarsys::File do
   describe ".create" do
     it "requests file creation with parameters" do
       stub_params = {:filename => 'my_file.jpg', :file => 'base_64_encoded_string'}
-      stub = stub_request(:post, "https://suite5.emarsys.net/api/v2/file").with(:body => stub_params.to_json).to_return(standard_return_body)
+      stub = stub_request(:post, "https://api.emarsys.net/api/v2/file").with(:body => stub_params.to_json).to_return(standard_return_body)
       Emarsys::File.create('my_file.jpg', 'base_64_encoded_string')
       stub.should have_been_requested.once
     end
 
     it "requests file creation with optional folder parameter" do
       stub_params = {:filename => 'my_file.jpg', :file => 'base_64_encoded_string', :folder => 3}
-      stub = stub_request(:post, "https://suite5.emarsys.net/api/v2/file").with(:body => stub_params.to_json).to_return(standard_return_body)
+      stub = stub_request(:post, "https://api.emarsys.net/api/v2/file").with(:body => stub_params.to_json).to_return(standard_return_body)
       Emarsys::File.create('my_file.jpg', 'base_64_encoded_string', 3)
       stub.should have_been_requested.once
     end

--- a/spec/emarsys/data_objects/source_spec.rb
+++ b/spec/emarsys/data_objects/source_spec.rb
@@ -9,7 +9,7 @@ describe Emarsys::Source do
 
   describe ".create" do
     it "requests source creation with parameters" do
-      stub = stub_request(:post, "https://suite5.emarsys.net/api/v2/source/create").with(:body => {:name => 'test_source'}.to_json).to_return(standard_return_body)
+      stub = stub_request(:post, "https://api.emarsys.net/api/v2/source/create").with(:body => {:name => 'test_source'}.to_json).to_return(standard_return_body)
       Emarsys::Source.create('test_source')
       stub.should have_been_requested.once
     end
@@ -17,7 +17,7 @@ describe Emarsys::Source do
 
   describe ".delete" do
     it "requests source deletion" do
-      stub = stub_request(:delete, "https://suite5.emarsys.net/api/v2/source/123").to_return(standard_return_body)
+      stub = stub_request(:delete, "https://api.emarsys.net/api/v2/source/123").to_return(standard_return_body)
       Emarsys::Source.destroy(123)
       stub.should have_been_requested.once
     end

--- a/spec/emarsys/request_spec.rb
+++ b/spec/emarsys/request_spec.rb
@@ -20,7 +20,7 @@ describe Emarsys::Request do
 
   describe '#emarsys_uri' do
     it 'concats api_endpoint with path' do
-      expect(request.emarsys_uri).to eq("https://suite5.emarsys.net/api/v2/some-path")
+      expect(request.emarsys_uri).to eq("https://api.emarsys.net/api/v2/some-path")
     end
   end
 

--- a/spec/emarsys_spec.rb
+++ b/spec/emarsys_spec.rb
@@ -16,7 +16,7 @@ describe Emarsys do
   describe ".api_endpoint getter" do
     it "returns specific url as default value" do
       Emarsys.api_endpoint = nil
-      Emarsys.api_endpoint.should eq('https://suite5.emarsys.net/api/v2')
+      Emarsys.api_endpoint.should eq('https://api.emarsys.net/api/v2')
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,7 +22,7 @@ def standard_return_body
 end
 
 def stub_get(path, &block)
-  stub = stub_request(:get, "https://suite5.emarsys.net/api/v2/#{path}").to_return(standard_return_body)
+  stub = stub_request(:get, "https://api.emarsys.net/api/v2/#{path}").to_return(standard_return_body)
   yield if block_given?
   stub
 end


### PR DESCRIPTION
This changes the default endpoint to `https://api.emarsys.net/api/v2/`, which is used throughout the Emarsys API documentation, and works regardless of "suite", if I'm not mistaken.