### PR TITLE
Use ? and url_encode to form get params

### DIFF
--- a/lib/emarsys/data_object.rb
+++ b/lib/emarsys/data_object.rb
@@ -47,9 +47,17 @@ module Emarsys
       # Custom Parameterizer for Emarsys
       #
       # @param params [Hash] custom params hash
-      # @return [String] key => value is returned as key=value
+      # @return [String] {key1 => value1, key2 => value2 is returned as ?key1=value1&key2=value2
       def parameterize_params(params)
-        params.inject(""){|string, (k, v)| string << "#{k}=#{v}"; string << "&"; string}[0..-2]
+        '?' + params.map{|k, v| "#{url_encode(k)}=#{url_encode(v)}"}.join('&')
+      end
+
+
+      private
+
+      # Encode params like Emarsys does
+      def url_encode(param)
+        ERB::Util.url_encode(param)
       end
     end
 

--- a/lib/emarsys/data_objects/contact.rb
+++ b/lib/emarsys/data_objects/contact.rb
@@ -29,7 +29,7 @@ module Emarsys
       #   Emarsys::Contact.emarsys_id('email', 'john.dow@example.com')
       #   Emarsys::Contact.emarsys_id(1, 'John')
       def emarsys_id(key_id, key_value)
-        get "contact/#{transform_key_id(key_id).to_s}=#{key_value.to_s}", {}
+        get "contact", {"#{transform_key_id(key_id).to_s}" => key_value}
       end
 
       # Update a contact. The given params are transformed to emarsys ids.

--- a/spec/emarsys/data_object_spec.rb
+++ b/spec/emarsys/data_object_spec.rb
@@ -10,7 +10,7 @@ describe Emarsys::DataObject do
       end
 
       it "transfers params to specific emarsys params format" do
-        Emarsys::DataObject.any_instance.should_receive(:request).with('get', 'test_method/a=1&b=2', {}).and_return(nil)
+        Emarsys::DataObject.any_instance.should_receive(:request).with('get', 'test_method/?a=1&b=2', {}).and_return(nil)
         Emarsys::DataObject.get('test_method', {'a' => 1, 'b' => 2})
       end
     end
@@ -39,7 +39,12 @@ describe Emarsys::DataObject do
     describe '.parameterize_params' do
       it "converts hash to params string" do
         params = {"a" => 1, "b" => 2, "c" => 3}
-        expect(Emarsys::DataObject.parameterize_params(params)).to eq("a=1&b=2&c=3")
+        expect(Emarsys::DataObject.parameterize_params(params)).to eq("?a=1&b=2&c=3")
+      end
+
+      it "url_encodes params" do
+        params = {"email" => "best/email@mail.org"}
+        expect(Emarsys::DataObject.parameterize_params(params)).to eq("?email=best%2Femail%40mail.org")
       end
     end
   end

--- a/spec/emarsys/data_objects/contact_spec.rb
+++ b/spec/emarsys/data_objects/contact_spec.rb
@@ -12,7 +12,7 @@ describe Emarsys::Contact do
 
   describe ".emarsys_id" do
     it "requests emarsys_id of a contact" do
-      stub = stub_request(:get, "https://api.emarsys.net/api/v2/contact/3=jane.doe@example.com").to_return(standard_return_body)
+      stub = stub_request(:get, "https://api.emarsys.net/api/v2/contact/?3=jane.doe@example.com").to_return(standard_return_body)
       Emarsys::Contact.emarsys_id(3, 'jane.doe@example.com')
       stub.should have_been_requested.once
     end

--- a/spec/emarsys/data_objects/email_spec.rb
+++ b/spec/emarsys/data_objects/email_spec.rb
@@ -7,15 +7,15 @@ describe Emarsys::Email do
     end
 
     it "requests all emails to the given status parameter" do
-      stub_get('email/status=3') { Emarsys::Email.collection({:status => 3}) }.should have_been_requested.once
+      stub_get('email/?status=3') { Emarsys::Email.collection({:status => 3}) }.should have_been_requested.once
     end
 
     it "requests all emails to the given contactlist parameter" do
-      stub_get('email/contactlist=123') { Emarsys::Email.collection({:contactlist => 123}) }.should have_been_requested.once
+      stub_get('email/?contactlist=123') { Emarsys::Email.collection({:contactlist => 123}) }.should have_been_requested.once
     end
 
     it "requests all emails - even with combined parameters" do
-      stub_get('email/status=3&contactlist=123') { Emarsys::Email.collection({:status => 3, :contactlist => 123}) }.should have_been_requested.once
+      stub_get('email/?status=3&contactlist=123') { Emarsys::Email.collection({:status => 3, :contactlist => 123}) }.should have_been_requested.once
     end
   end
 

--- a/spec/emarsys/data_objects/file_spec.rb
+++ b/spec/emarsys/data_objects/file_spec.rb
@@ -7,7 +7,7 @@ describe Emarsys::File do
     end
 
     it "requests all files with parameter" do
-      stub_get("file/folder=3") { Emarsys::File.collection(:folder => 3) }.should have_been_requested.once
+      stub_get("file/?folder=3") { Emarsys::File.collection(:folder => 3) }.should have_been_requested.once
     end
   end
 

--- a/spec/emarsys/data_objects/folder_spec.rb
+++ b/spec/emarsys/data_objects/folder_spec.rb
@@ -7,7 +7,7 @@ describe Emarsys::Folder do
     end
 
     it "requests all folders with parameters" do
-      stub_get("folder/folder=3") { Emarsys::Folder.collection(:folder => 3) }.should have_been_requested.once
+      stub_get("folder/?folder=3") { Emarsys::Folder.collection(:folder => 3) }.should have_been_requested.once
     end
   end
 end


### PR DESCRIPTION
In call emarsys_id(key_id, key_value) with email 'best/email@smth.org' 
gem formed incorrect request like get 'api/contact/email=best/email@smth.org'

To fix it I changed code to make request like get 'api/contact/?email=best%2Femail%40smth.org
- add ? before first param
- url_encode all params

I have checked Emarsys API demo at https://suite11.emarsys.net/api-demo/#tab-contact
They send the same response: 
GET https://suite11.emarsys.net/api/v2/contact/?email=best%2Femail%40smth.org

By the way, emails with / are correct, according to standart: https://tools.ietf.org/html/rfc5322#section-3.4.1

https://en.wikipedia.org/wiki/Email_address