### PR TITLE
Fixed validation error with nonce

### DIFF
--- a/lib/emarsys/client.rb
+++ b/lib/emarsys/client.rb
@@ -1,6 +1,5 @@
 module Emarsys
   class Client
-    attr_accessor :nonce
     def username
       raise ArgumentError, "Emarsys.api_username is not set" if Emarsys.api_username.nil?
       Emarsys.api_username
@@ -28,7 +27,6 @@ module Emarsys
       return @nonce if @nonce
       bytes = Random::DEFAULT.bytes(16)
       @nonce = bytes.each_byte.map { |b| sprintf("%02X",b) }.join
-      @nonce
     end
 
     def header_created
@@ -36,7 +34,7 @@ module Emarsys
     end
 
     def calculated_digest
-      Digest::SHA1.new.hexdigest(header_nonce + header_created + password)
+      Digest::SHA1.hexdigest(header_nonce + header_created + password)
     end
 
   end

--- a/lib/emarsys/client.rb
+++ b/lib/emarsys/client.rb
@@ -13,9 +13,9 @@ module Emarsys
 
     def x_wsse_string
       string = 'UsernameToken '
-      string += 'Username="' + username + '", '
-      string += 'PasswordDigest="' + header_password_digest + '", '
-      string += 'Nonce="' + header_nonce + '", '
+      string += 'Username="' + username + '",'
+      string += 'PasswordDigest="' + header_password_digest + '",'
+      string += 'Nonce="' + header_nonce + '",'
       string += 'Created="' + header_created + '"'
       string
     end

--- a/lib/emarsys/client.rb
+++ b/lib/emarsys/client.rb
@@ -1,6 +1,6 @@
 module Emarsys
   class Client
-
+    attr_accessor :nonce
     def username
       raise ArgumentError, "Emarsys.api_username is not set" if Emarsys.api_username.nil?
       Emarsys.api_username
@@ -25,8 +25,10 @@ module Emarsys
     end
 
     def header_nonce
+      return @nonce if @nonce
       bytes = Random::DEFAULT.bytes(16)
-      bytes.each_byte.map { |b| sprintf("%02X",b) }.join
+      @nonce = bytes.each_byte.map { |b| sprintf("%02X",b) }.join
+      @nonce
     end
 
     def header_created

--- a/lib/emarsys/client.rb
+++ b/lib/emarsys/client.rb
@@ -12,16 +12,16 @@ module Emarsys
     end
 
     def x_wsse_string
-      string = 'UsernameToken '
-      string += 'Username="' + username + '",'
-      string += 'PasswordDigest="' + header_password_digest + '",'
-      string += 'Nonce="' + header_nonce + '",'
-      string += 'Created="' + header_created + '"'
-      string
+      'UsernameToken ' +
+      "Username=\"#{username}\", " +
+      "PasswordDigest=\"#{header_password_digest}\", " +
+      "Nonce=\"#{header_nonce}\", " +
+      "Created=\"#{header_created}\""
     end
 
     def header_password_digest
-      Base64.encode64(calculated_digest).gsub("\n", "")
+      # Base64.encode64(calculated_digest).gsub("\n", "")
+      Base64.encode64().strip
     end
 
     def header_nonce
@@ -34,7 +34,7 @@ module Emarsys
     end
 
     def calculated_digest
-      Digest::SHA1.hexdigest(header_nonce + header_created + password)
+      Digest::SHA1.new.hexdigest(header_nonce + header_created + password)
     end
 
   end

--- a/lib/emarsys/client.rb
+++ b/lib/emarsys/client.rb
@@ -21,7 +21,7 @@ module Emarsys
 
     def header_password_digest
       # Base64.encode64(calculated_digest).gsub("\n", "")
-      Base64.encode64().strip
+      Base64.encode64(calculated_digest).strip
     end
 
     def header_nonce

--- a/spec/emarsys/client_spec.rb
+++ b/spec/emarsys/client_spec.rb
@@ -57,6 +57,12 @@ describe Emarsys::Client do
       it 'uses 16 random bytes to generate a 32 char hex string' do
         expect(Emarsys::Client.new.header_nonce).to match(/^[0-9a-f]{32}$/i)
       end
+
+      it 'only sets the nonce once' do
+        client = Emarsys::Client.new
+        nonce = client.header_nonce
+        expect(client.header_nonce).to eq nonce
+      end
     end
 
     describe '#header_created' do


### PR DESCRIPTION
There was an issue where the nonce was being created twice during authentication. This was resulting in two separate nonces being sent across and thus validation would fail.

This resolves that issue.
