### PR TITLE
Cleaner way to build header string

### DIFF
--- a/lib/emarsys/client.rb
+++ b/lib/emarsys/client.rb
@@ -12,10 +12,9 @@ module Emarsys
     end
 
     def x_wsse_string
-      str = <<-STRING
+      <<-STRING.strip
       UsernameToken Username="#{username}", PasswordDigest="#{header_password_digest}", Nonce="#{header_nonce}", Created="#{header_created}"
       STRING
-      str.strip
     end
 
     def header_password_digest

--- a/lib/emarsys/client.rb
+++ b/lib/emarsys/client.rb
@@ -12,12 +12,10 @@ module Emarsys
     end
 
     def x_wsse_string
-      string = 'UsernameToken '
-      string += 'Username="' + username + '", '
-      string += 'PasswordDigest="' + header_password_digest + '", '
-      string += 'Nonce="' + header_nonce + '", '
-      string += 'Created="' + header_created + '"'
-      string
+      str = <<-STRING
+      UsernameToken Username="#{username}", PasswordDigest="#{header_password_digest}", Nonce="#{header_nonce}", Created="#{header_created}"
+      STRING
+      str.strip
     end
 
     def header_password_digest


### PR DESCRIPTION
This is just a 'cleanup', which handles building the header string in a slightly more readable way (no battling ' vs ").

No additional spec coverage as original specs cover the same case, and output should be identical.