### PR TITLE
Fix bug with nonce creation causing error from Emarsys API

### DIFF
--- a/lib/emarsys/client.rb
+++ b/lib/emarsys/client.rb
@@ -25,8 +25,7 @@ module Emarsys
     end
 
     def header_nonce
-      bytes = Random::DEFAULT.bytes(16)
-      bytes.each_byte.map { |b| sprintf("%02X",b) }.join
+      @header_nonce ||= Random::DEFAULT.bytes(16).each_byte.map { |b| sprintf("%02X",b) }.join
     end
 
     def header_created

--- a/spec/emarsys/client_spec.rb
+++ b/spec/emarsys/client_spec.rb
@@ -57,6 +57,12 @@ describe Emarsys::Client do
       it 'uses 16 random bytes to generate a 32 char hex string' do
         expect(Emarsys::Client.new.header_nonce).to match(/^[0-9a-f]{32}$/i)
       end
+
+      it 'only creates the nonce once' do
+        client = Emarsys::Client.new
+        nonce = client.header_nonce
+        expect(client.header_nonce).to eq nonce
+      end
     end
 
     describe '#header_created' do


### PR DESCRIPTION
This fixes a bug in the client auth code, which creates the header nonce twice.  This is an alternative PR to #15 