### PR TITLE
Add support for rate-limiting response

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,14 @@ A utility method is provided to map to Emarsys internal country IDs from ISO 316
 => {:id=>185, :name=>"United States of America"}
 ```
 
+### Rate Limiting
+
+The Emarsys API documentation states you can make "at least 200 requests per minute", which is reasonably slow - in practice, the Emarsys API seems to handle rates of up to about 60-70 req/sec before complaining.
+
+If you exceed the limit, the Emarsys API returns an HTTP 429 'Too Many Requests' response. The client library will raise an error in this case.
+
+
+
 ## Interacting with the API
 
 You can interact with the API on the provided data objects:

--- a/lib/emarsys/error.rb
+++ b/lib/emarsys/error.rb
@@ -20,6 +20,9 @@ module Emarsys
   # Raised when Emarsys returns a 401 HTTP status code
   class Unauthorized < Error; end
 
+  # Raised when Emarsys returns a 429 HTTP status code
+  class TooManyRequests < Error; end
+
   # Raised when Emarsys returns a 500 HTTP status code
   class InternalServerError < Error; end
 end

--- a/lib/emarsys/response.rb
+++ b/lib/emarsys/response.rb
@@ -18,6 +18,8 @@ module Emarsys
         raise Emarsys::Unauthorized.new(code, text, status)
       else
         raise Emarsys::BadRequest.new(code, text, status)
+      else
+        raise Emarsys::TooManyRequests.new(code, text, status)
       end
     end
 

--- a/lib/emarsys/response.rb
+++ b/lib/emarsys/response.rb
@@ -16,10 +16,10 @@ module Emarsys
         data
       elsif !status.nil? && status == 401
         raise Emarsys::Unauthorized.new(code, text, status)
+      elsif !status.nil? && status == 429
+        raise Emarsys::TooManyRequests.new(code, text, status)
       else
         raise Emarsys::BadRequest.new(code, text, status)
-      else
-        raise Emarsys::TooManyRequests.new(code, text, status)
       end
     end
 

--- a/spec/emarsys/response_spec.rb
+++ b/spec/emarsys/response_spec.rb
@@ -30,6 +30,12 @@ describe Emarsys::Response do
       allow(response).to receive(:status).and_return(401)
       expect{response.result}.to raise_error(Emarsys::Unauthorized)
     end
+
+    it "raises TooManyRequests error if http-status is 429" do
+      allow(response).to receive(:code).and_return(1)
+      allow(response).to receive(:status).and_return(429)
+      expect{response.result}.to raise_error(Emarsys::TooManyRequests)
+    end
   end
 
 end


### PR DESCRIPTION
This adds initial support for the Emarsys rate-limiting features.  If you exceed the rate limit, Emarsys returns a 429 error - this PR adds support for detecting this error case and raising an appropriate error.

Future work may add support for exposing the rate-limit headers on each response, but thats out of scope for this PR.