### PR TITLE
Implement Emarsys::Email.export_responses and Emarsys::Export.data

### DIFF
--- a/lib/emarsys/data_objects/email.rb
+++ b/lib/emarsys/data_objects/email.rb
@@ -125,9 +125,33 @@ module Emarsys
         raise "Not implemented yet"
       end
 
-      # TODO POST /getresponses
-      def export_responses(params = {})
-        raise "Not implemented yet"
+      # Exports the selected fields of all contacts who responded to emails
+      # within the specified time range.
+      #
+      # @param distribution_method [String] ftp or local
+      # @param time_range [array] Array with two elements (start date, end date)
+      # @param contact_fields [array] Array of contact field IDs
+      # @param sources [array] Array which defines sources
+      # @param analysis_fields [array] Array that defines the contact behaviours to analyse
+      # @option params [hash]
+      # @return [Hash] Result data
+      # @example
+      #   Emarsys::Email.export_responses(
+      #     'local',
+      #     ['2012-02-09', '2014-08-13'],
+      #     [1, 3],
+      #     ['trackable_links'],
+      #     [5, 8, 13]
+      #   )
+      def export_responses(distribution_method, time_range, contact_fields, sources, analysis_fields, params = {})
+        params.merge!(
+          :distribution_method => distribution_method,
+          :time_range => time_range,
+          :contact_fields => Emarsys::ParamsConverter.new(contact_fields).convert_to_ids,
+          :sources => sources,
+          :analysis_fields => analysis_fields
+        )
+        post "email/getresponses", params
       end
     end
   end

--- a/lib/emarsys/data_objects/export.rb
+++ b/lib/emarsys/data_objects/export.rb
@@ -16,6 +16,21 @@ module Emarsys
       def resource(id)
         get "export/#{id}", {}
       end
+
+      # Download export data
+      #
+      # @param id [Integer, String] The internal emarsys id
+      # @option offset [Integer] Defines the ID to start listing from
+      # @option limit [Integer] Defines how many IDs are listed
+      # @return [String] text/csv
+      # @example
+      #   Emarsys::Export.data(2)
+      def data(id, offset = nil, limit = nil)
+        params = {}
+        params.merge!(:offset => offset) if offset
+        params.merge!(:limit => limit) if limit
+        get "export/#{id}/data", params
+      end
     end
 
   end

--- a/lib/emarsys/params_converter.rb
+++ b/lib/emarsys/params_converter.rb
@@ -9,12 +9,7 @@ module Emarsys
     end
 
     def convert_to_ids
-      new_hash = {}
-      params.each do |key, value|
-        matching_attributes = Emarsys::FieldMapping::ATTRIBUTES.find{|elem| elem[:identifier] == key.to_s}
-        new_hash.merge!({ (matching_attributes.nil? ? key : matching_attributes[:id]) => value })
-      end
-      new_hash
+      params.is_a?(Hash) ? convert_hash_to_ids : convert_array_to_ids
     end
 
     def convert_to_identifiers
@@ -24,6 +19,26 @@ module Emarsys
         new_hash.merge!({ (matching_attributes.nil? ? key : matching_attributes[:identifier]) => value })
       end
       new_hash
+    end
+
+    private
+
+    def convert_hash_to_ids
+      new_hash = {}
+      params.each do |key, value|
+        matching_attributes = Emarsys::FieldMapping::ATTRIBUTES.find{|elem| elem[:identifier] == key.to_s}
+        new_hash.merge!({ (matching_attributes.nil? ? key : matching_attributes[:id]) => value })
+      end
+      new_hash
+    end
+
+    def convert_array_to_ids
+      new_array = []
+      params.each do |key|
+        matching_attributes = Emarsys::FieldMapping::ATTRIBUTES.find{|elem| elem[:identifier] == key.to_s}
+        new_array << (matching_attributes.nil? ? key : matching_attributes[:id])
+      end
+      new_array
     end
 
   end

--- a/lib/emarsys/response.rb
+++ b/lib/emarsys/response.rb
@@ -4,10 +4,15 @@ module Emarsys
     attr_accessor :code, :text, :data, :status
 
     def initialize(response)
-      json = JSON.parse(response)
-      self.code = json['replyCode']
-      self.text = json['replyText']
-      self.data = json['data']
+      if response.headers[:content_type] == 'text/csv'
+        self.code = 0
+        self.data = response.body
+      else
+        json = JSON.parse(response)
+        self.code = json['replyCode']
+        self.text = json['replyText']
+        self.data = json['data']
+      end
       self.status = response.code if response.respond_to?(:code)
     end
 

--- a/spec/emarsys/data_objects/export_spec.rb
+++ b/spec/emarsys/data_objects/export_spec.rb
@@ -8,4 +8,12 @@ describe Emarsys::Export do
       ).to have_been_requested.once
     end
   end
+
+  describe ".data" do
+    it "requests export data" do
+      expect(
+        stub_get('export/123/data') { Emarsys::Export.data(123) }
+      ).to have_been_requested.once
+    end
+  end
 end

--- a/spec/emarsys/response_spec.rb
+++ b/spec/emarsys/response_spec.rb
@@ -2,18 +2,54 @@ require 'spec_helper'
 
 describe Emarsys::Response do
 
+  class FakeResponse
+    attr_accessor :body
+
+    def initialize(body)
+      self.body = body
+    end
+
+    def to_str
+      body
+    end
+
+    module JSON
+      # Value taken from an actual response from Emarsys
+      def headers
+        {:content_type => 'text/html; charset=utf-8'}
+      end
+    end
+
+    module CSV
+      def headers
+        {:content_type => 'text/csv'}
+      end
+    end
+  end
+
   describe '#initialize' do
-    it 'sets code, text and data attributes on initialize' do
-      response_string = "{\"replyCode\":0,\"replyText\":\"Something\",\"data\":1}"
-      response = Emarsys::Response.new(response_string)
-      expect(response.code).to eq(0)
-      expect(response.text).to eq("Something")
-      expect(response.data).to eq(1)
+    context "json" do
+      let(:response_string) { "{\"replyCode\":0,\"replyText\":\"Something\",\"data\":1}" }
+      let(:response) { Emarsys::Response.new(FakeResponse.new(response_string).extend(FakeResponse::JSON)) }
+      it 'sets code, text and data attributes on initialize' do
+        expect(response.code).to eq(0)
+        expect(response.text).to eq("Something")
+        expect(response.data).to eq(1)
+      end
+    end
+    context "csv" do
+      let(:response_string) { "user_id,Vorname,E-Mail,Version Name,Url,Zeit\r\n" }
+      let(:response) { Emarsys::Response.new(FakeResponse.new(response_string).extend(FakeResponse::CSV)) }
+      it 'sets code and data attributes on initialize' do
+        expect(response.code).to eq(0)
+        expect(response.data).to eq("user_id,Vorname,E-Mail,Version Name,Url,Zeit\r\n")
+      end
     end
   end
 
   describe '#result' do
-    let(:response) { Emarsys::Response.new("{\"replyCode\":0,\"replyText\":\"Something\",\"data\":1}") }
+    let(:response_string) { "{\"replyCode\":0,\"replyText\":\"Something\",\"data\":1}" }
+    let(:response) { Emarsys::Response.new(FakeResponse.new(response_string).extend(FakeResponse::JSON)) }
 
     it "returns data if code is 0" do
       allow(response).to receive(:code).and_return(0)


### PR DESCRIPTION
It is now possible to create an export via API, and to download it once it is
done.

When creating an export, contact fields need to be given as an
array. To support converting the identifiers to field IDs,
Emarsys::ParamsConverter was adapted to deal with arrays, too.

The export download is a special endpoint that does not return JSON, but
text/csv if the call is successful (JSON otherwise). To support this,
Emarsys::Response needed to handle non-JSON responses, too.