### PR TITLE
Allow to configure open_timeout and read_timeout

### DIFF
--- a/lib/emarsys/client.rb
+++ b/lib/emarsys/client.rb
@@ -40,5 +40,13 @@ module Emarsys
     def calculated_digest
       Digest::SHA1.hexdigest(header_nonce + header_created + password)
     end
+
+    def open_timeout
+      Emarsys::Configuration.for(account).open_timeout
+    end
+
+    def read_timeout
+      Emarsys::Configuration.for(account).read_timeout
+    end
   end
 end

--- a/lib/emarsys/configuration.rb
+++ b/lib/emarsys/configuration.rb
@@ -50,5 +50,11 @@ module Emarsys
       @api_password or raise ArgumentError.new('api_password is not set')
     end
 
+    # @!attribute open_timeout
+    #   @return [Integer] Connect Timeout. default: RestClient timeout which is 60s
+    # @!attribute read_timeout
+    #   @return [Integer] Read Timeout. default: RestClient timeout which is 60s
+    attr_accessor :open_timeout, :read_timeout
+
   end
 end

--- a/lib/emarsys/request.rb
+++ b/lib/emarsys/request.rb
@@ -6,29 +6,32 @@ module Emarsys
 
     def initialize(account, http_verb, path, params = {})
       self.path = path
-      self.http_verb = http_verb
+      self.http_verb = http_verb.to_sym
       self.params = params
       self.account = account
     end
 
     def send_request
-      case http_verb.to_sym
-      when :post
-        RestClient.post(emarsys_uri, converted_params.to_json, :content_type => :json, :x_wsse => client.x_wsse_string) do |response, request, result, &block|
-          Emarsys::Response.new(response)
-        end
-      when :put
-        RestClient.put emarsys_uri, converted_params.to_json, :content_type => :json, :x_wsse => client.x_wsse_string do |response, request, result, &block|
-          Emarsys::Response.new(response)
-        end
-      when :delete
-        RestClient.delete(emarsys_uri, :content_type => :json, :x_wsse => client.x_wsse_string) do |response, request, result, &block|
-          Emarsys::Response.new(response)
-        end
-      else
-        RestClient.get(emarsys_uri, :content_type => :json, :x_wsse => client.x_wsse_string) do |response, request, result, &block|
-          Emarsys::Response.new(response)
-        end
+      args = {
+        method: http_verb,
+        url: emarsys_uri,
+        headers: { content_type: :json, x_wsse: client.x_wsse_string }
+      }
+
+      if client.open_timeout
+        args.merge!(open_timeout: client.open_timeout)
+      end
+
+      if client.read_timeout
+        args.merge!(read_timeout: client.read_timeout)
+      end
+
+      if [:post, :put].include?(http_verb)
+        args.merge!(payload: converted_params.to_json)
+      end
+
+      RestClient::Request.execute(args) do |response, request, result, &block|
+        Emarsys::Response.new(response)
       end
     end
 

--- a/spec/emarsys/request_spec.rb
+++ b/spec/emarsys/request_spec.rb
@@ -1,12 +1,11 @@
 require 'spec_helper'
 
 describe Emarsys::Request do
-  let(:client) { Emarsys::Client.new }
   let(:request) { Emarsys::Request.new(nil, 'get', 'some-path', {:a => 1}) }
 
   describe '#initialize' do
     it 'sets client, path, http_verb and params attributes on initialize' do
-      expect(request.http_verb).to eq('get')
+      expect(request.http_verb).to eq(:get)
       expect(request.path).to eq("some-path")
       expect(request.params).to eq({:a => 1})
     end
@@ -21,6 +20,18 @@ describe Emarsys::Request do
   describe '#emarsys_uri' do
     it 'concats api_endpoint with path' do
       expect(request.emarsys_uri).to eq("https://api.emarsys.net/api/v2/some-path")
+    end
+  end
+
+  describe '#send_request' do
+    let(:client) { Emarsys::Client.new }
+    it 'sets timeouts if configured' do
+      allow(request).to receive(:client).and_return(client)
+      allow(client).to receive(:read_timeout).and_return(2)
+      expect(RestClient::Request).to receive(:execute).with(
+        hash_including(read_timeout: 2)
+      )
+      request.send_request
     end
   end
 


### PR DESCRIPTION
Previously, the default timeouts of RestClient were used.
According to
https://github.com/ankane/the-ultimate-guide-to-ruby-timeouts#rest-client,
both open_timeout and read_timeout is 60s then.

Now it is possible to configure open_timeout and/or read_timeout. If a value
is set, that is used, otherwise the default of RestClient is used.

Addresses #40.