### PR TITLE
Enable response summary api with optional params

### DIFF
--- a/lib/emarsys/data_objects/email.rb
+++ b/lib/emarsys/data_objects/email.rb
@@ -81,14 +81,23 @@ module Emarsys
         post account, "email/#{id}/preview", {:version => version}
       end
 
-      # View response summary of an email
-      #
-      # @param id [Integer, String] Internal email id
-      # @return [Hash] Result data
-      # @example
-      #   Emarsys::Email.response_summary(1)
-      def response_summary(id, account: nil)
-        get account, "email/#{id}/responsesummary", {}
+      # http://documentation.emarsys.com/resource/developers/endpoints/email/response-summary/
+      def response_summary(id, launch_id: nil, start_date: nil, end_date: nil, account: nil)
+        params = {}
+
+        if !launch_id.nil?
+          params.merge!(launch_id: launch_id) 
+        end
+
+        if !start_date.nil? 
+          params.merge!(start_date: start_date)
+        end
+
+        if !end_date.nil?
+          params.merge!(end_date: end_date)
+        end
+
+        get account, "email/#{id}/responsesummary", params
       end
 
       # Instruct emarsys to send a test mail

--- a/spec/emarsys/data_objects/email_spec.rb
+++ b/spec/emarsys/data_objects/email_spec.rb
@@ -85,8 +85,13 @@ describe Emarsys::Email do
 
   describe ".response_summary" do
     it "requests a single email" do
-      expect(
-        stub_get('email/123/responsesummary') { Emarsys::Email.response_summary(123) }
+      stub_params = {
+        launch_id: 123,
+        start_date: '2013-12-01 23:00:00',
+        end_date: '2013-12-02 23:00:00'
+      }
+      expect(stub_get('email/123/responsesummary/?end_date=2013-12-02%2023:00:00&launch_id=123&start_date=2013-12-01%2023:00:00') { 
+        Emarsys::Email.response_summary(123, stub_params) }
       ).to have_been_requested.once
     end
   end


### PR DESCRIPTION
Optional params: launch_id, start_date, end_date