### PR TITLE
segmentation fault with ruby 2.2.[4-7] in forked environments

### DIFF
--- a/lib/emarsys.rb
+++ b/lib/emarsys.rb
@@ -3,6 +3,7 @@ require "base64"
 require 'json'
 require 'rest_client'
 require 'uri'
+require 'securerandom'
 
 require 'emarsys/configuration'
 require 'emarsys/client'

--- a/lib/emarsys/client.rb
+++ b/lib/emarsys/client.rb
@@ -30,7 +30,7 @@ module Emarsys
     end
 
     def header_nonce
-      @header_nonce ||= Random::DEFAULT.bytes(16).each_byte.map { |b| sprintf("%02X",b) }.join
+      @header_nonce ||= SecureRandom::random_bytes(16).each_byte.map { |b| sprintf("%02X",b) }.join
     end
 
     def header_created

--- a/spec/emarsys/client_spec.rb
+++ b/spec/emarsys/client_spec.rb
@@ -76,7 +76,7 @@ describe Emarsys::Client do
             expect(client.header_nonce).to eq nonce
           end
         end
-      end
+      end if RUBY_ENGINE == 'ruby'
     end
 
     describe '#header_created' do

--- a/spec/emarsys/client_spec.rb
+++ b/spec/emarsys/client_spec.rb
@@ -67,6 +67,16 @@ describe Emarsys::Client do
         nonce = client.header_nonce
         expect(client.header_nonce).to eq nonce
       end
+
+      describe 'in a forked environment' do
+        it 'will not break apart' do
+          fork do
+            client = Emarsys::Client.new
+            nonce = client.header_nonce
+            expect(client.header_nonce).to eq nonce
+          end
+        end
+      end
     end
 
     describe '#header_created' do


### PR DESCRIPTION
fixes a segmentation fault problem when executed in forked environments
e.g. when running in background workers like `resque`

the actual bug is in Ruby (https://bugs.ruby-lang.org/issues/13753), but to also
allow older 2.2.x releases to make use of this gem i swapped the call to
`Random::DEFAULT.bytes` with `SecureRandom.random_bytes` which is
not affected by this problem but should work in nearly similar ways.

its easy to see the effects in `irb`, try the following and watch it 🔥 

```
fork do
  puts Random::DEFAULT.bytes(16).each_byte.map { |b| sprintf("%02X",b) }.join
end

fork do
  puts SecureRandom.random_bytes(16).each_byte.map { |b| sprintf("%02X",b) }.join
end
```

