### PR TITLE
Email unsubscribe tracking

### DIFF
--- a/lib/emarsys/data_objects/email.rb
+++ b/lib/emarsys/data_objects/email.rb
@@ -120,6 +120,19 @@ module Emarsys
         post account, "email/#{id}/getdeliverystatus", params
       end
 
+      # Tracking email campaign unsubscribes
+      #
+      # @param params [hash] unsubscribe parameters
+      # @option params [String] 'contact_uid'
+      # @option params [String] 'email_id'
+      # @option params [String] 'launch_list_id'
+      # @return [Hash] Result data
+      # @example
+      #   Emarsys::Email.unsubscribe({contact_uid: '1', email_id: '1', launch_list_id: '1'})
+      def unsubscribe(account: nil, **params)
+        post account, "email/unsubscribe", params
+      end
+
       # TODO POST /getlaunchesofemail
       def email_launches(id, account: nil)
         raise "Not implemented yet"

--- a/spec/emarsys/data_objects/email_spec.rb
+++ b/spec/emarsys/data_objects/email_spec.rb
@@ -83,6 +83,16 @@ describe Emarsys::Email do
     end
   end
 
+  describe ".unsubscribe" do
+    it "requests an email test sending with custom recipient list" do
+      stub_params = {contact_uid: '1', email_id: '1', launch_list_id: '1'}
+      stub = stub_request(:post, "https://api.emarsys.net/api/v2/email/unsubscribe").with(:body => stub_params.to_json).to_return(standard_return_body)
+
+      Emarsys::Email.unsubscribe(stub_params)
+      expect(stub).to have_been_requested.once
+    end
+  end
+
   describe ".response_summary" do
     it "requests a single email" do
       expect(

--- a/spec/emarsys/data_objects/email_spec.rb
+++ b/spec/emarsys/data_objects/email_spec.rb
@@ -84,7 +84,7 @@ describe Emarsys::Email do
   end
 
   describe ".unsubscribe" do
-    it "requests an email test sending with custom recipient list" do
+    it "tracks unsubscribes with contact and list details" do
       stub_params = {contact_uid: '1', email_id: '1', launch_list_id: '1'}
       stub = stub_request(:post, "https://api.emarsys.net/api/v2/email/unsubscribe").with(:body => stub_params.to_json).to_return(standard_return_body)
 


### PR DESCRIPTION
implements the `unsubscribe` endpoint for tracking campaign unsubscribes

http://documentation.emarsys.com/resource/developers/endpoints/email/unsubscribe-from-launch/

see #48 