### PR TITLE
Add option to pass attachment to Event.trigger method

### DIFF
--- a/lib/emarsys/data_objects/event.rb
+++ b/lib/emarsys/data_objects/event.rb
@@ -23,14 +23,16 @@ module Emarsys
       # @param key_id [Integer, String] The identifer of the key field (e.g. 3 for 'email')
       # @param external_id [String] The id of the given filed specified with key_id (e.g. 'test@example.com')
       # @option data [Hash] data hash for transactional mails
+      # @option attachment [Array] array containing an attachment for transactional mails
       # @return [Hash] Result data
       # @example
       #   Emarsys::Event.trigger(2, 3, 'test@example.com')
       #   Emarsys::Event.trigger(2, 'user_id', 57687, {:global => {:name => "Special Name"}})
-      def trigger(id, key_id:, external_id:, data: {}, account: nil)
+      def trigger(id, key_id:, external_id:, data: {}, attachment: [], account: nil)
         transformed_key_id = transform_key_id(key_id)
-        params = {:key_id => transformed_key_id, :external_id => external_id}
-        params.merge!(:data => data) if not data.empty?
+        params = { key_id: transformed_key_id, external_id: external_id }
+        params.merge!(data: data) if not data.empty?
+        params.merge!(attachment: attachment) if not attachment.empty?
         post account, "event/#{id}/trigger", params
       end
 

--- a/spec/emarsys/data_objects/event_spec.rb
+++ b/spec/emarsys/data_objects/event_spec.rb
@@ -21,6 +21,12 @@ describe Emarsys::Event do
       Emarsys::Event.trigger(123, key_id: 3, external_id: 'jane.doe@example.com', data: {'global' => {'my_placeholder' => 'Something'}})
       expect(stub).to have_been_requested.once
     end
+
+    it "requests event trigger with an attachment" do
+      stub = stub_request(:post, "https://api.emarsys.net/api/v2/event/123/trigger").with(:body => {'key_id' => 3, 'external_id' => "jane.doe@example.com", attachment: [ {  filename: 'something.pdf', data:  'Something' } ]}.to_json).to_return(standard_return_body)
+      Emarsys::Event.trigger(123, key_id: 3, external_id: 'jane.doe@example.com', attachment: [ {  filename: 'something.pdf', data:  'Something' } ])
+      expect(stub).to have_been_requested.once
+    end
   end
 
   describe ".trigger_multiple" do


### PR DESCRIPTION
Emarsys added an option to attach files to events. (Currently only attaching one file is supported AFAIK)
https://help.emarsys.com/hc/en-us/articles/115004461489-Triggered-Email-End-User-Guide#using-attachments

This PR adds an optional parameter to attach a file