### PR TITLE
Fix constant re-definition warning and ensure backward-compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,14 +70,14 @@ which that can be overwritten. It will be picked up automatically. E.g.:
 
 ```ruby
 # Complete overwrite
-Emarsys::FieldMapping::ATTRIBUTES = [
+Emarsys::FieldMapping.set_attributes([
   {:id => 0, :identifier => 'interests', :name => 'Interests'},
   {:id => 1, :identifier => 'firstname', :name => 'First Name'},
   {:id => 2, :identifier => 'lastname',  :name => 'Last Name'},
-]
+])
 
 # Add to the Mapping-Constant
-Emarsys::FieldMapping::ATTRIBUTES << {:id => 100, :identifier => 'user_id', :name => "User-ID"}
+Emarsys::FieldMapping.add_attributes({:id => 100, :identifier => 'user_id', :name => "User-ID"})
 ```
 
 All Emarsys predefined system fields are prefixed with an underscore, e.g. '_firstname' or '_revenue' in order to not

--- a/lib/emarsys/data_objects/contact.rb
+++ b/lib/emarsys/data_objects/contact.rb
@@ -135,7 +135,7 @@ module Emarsys
 
       # @private
       def transform_key_id(key_id)
-        matching_attributes = Emarsys::FieldMapping::ATTRIBUTES.find{|elem| elem[:identifier] == key_id.to_s}
+        matching_attributes = Emarsys::FieldMapping.attributes.find{|elem| elem[:identifier] == key_id.to_s}
         matching_attributes.nil? ? key_id : matching_attributes[:id]
       end
 

--- a/lib/emarsys/data_objects/event.rb
+++ b/lib/emarsys/data_objects/event.rb
@@ -52,7 +52,7 @@ module Emarsys
 
       # @private
       def transform_key_id(key_id)
-        matching_attributes = Emarsys::FieldMapping::ATTRIBUTES.find{|elem| elem[:identifier] == key_id.to_s}
+        matching_attributes = Emarsys::FieldMapping.attributes.find{|elem| elem[:identifier] == key_id.to_s}
         matching_attributes.nil? ? key_id : matching_attributes[:id]
       end
     end

--- a/lib/emarsys/field_mapping.rb
+++ b/lib/emarsys/field_mapping.rb
@@ -53,4 +53,23 @@ module Emarsys::FieldMapping
     {:id => 48,  :identifier => '_date_of_first_registration', :name => 'Date of first registration'}
   ]
 
+  def self.attributes
+    return @custom_attributes if excluded_default_attributes?
+    return ATTRIBUTES.dup.concat(@custom_attributes) if @custom_attributes
+    ATTRIBUTES
+  end
+
+  def self.set_attributes(attrs)
+    @exclude_default_attributes = true
+    @custom_attributes = [attrs].flatten
+  end
+
+  def self.add_attributes(attrs)
+    @custom_attributes.concat([attrs].flatten)
+  end
+
+  def self.excluded_default_attributes?
+    @exclude_default_attributes == true
+  end
+
 end

--- a/lib/emarsys/params_converter.rb
+++ b/lib/emarsys/params_converter.rb
@@ -15,7 +15,7 @@ module Emarsys
     def convert_to_identifiers
       new_hash = {}
       params.each do |key, value|
-        matching_attributes = Emarsys::FieldMapping::ATTRIBUTES.find{|elem| elem[:id] == key.to_i && key.to_i != 0}
+        matching_attributes = Emarsys::FieldMapping.attributes.find{|elem| elem[:id] == key.to_i && key.to_i != 0}
         new_hash.merge!({ (matching_attributes.nil? ? key : matching_attributes[:identifier]) => value })
       end
       new_hash
@@ -26,7 +26,7 @@ module Emarsys
     def convert_hash_to_ids
       new_hash = {}
       params.each do |key, value|
-        matching_attributes = Emarsys::FieldMapping::ATTRIBUTES.find{|elem| elem[:identifier] == key.to_s}
+        matching_attributes = Emarsys::FieldMapping.attributes.find{|elem| elem[:identifier] == key.to_s}
         new_hash.merge!({ (matching_attributes.nil? ? key : matching_attributes[:id]) => value })
       end
       new_hash
@@ -35,7 +35,7 @@ module Emarsys
     def convert_array_to_ids
       new_array = []
       params.each do |key|
-        matching_attributes = Emarsys::FieldMapping::ATTRIBUTES.find{|elem| elem[:identifier] == key.to_s}
+        matching_attributes = Emarsys::FieldMapping.attributes.find{|elem| elem[:identifier] == key.to_s}
         new_array << (matching_attributes.nil? ? key : matching_attributes[:id])
       end
       new_array

--- a/spec/emarsys/field_mapping_spec.rb
+++ b/spec/emarsys/field_mapping_spec.rb
@@ -8,7 +8,67 @@ describe Emarsys::FieldMapping do
 
   it "defines constant ATTRBUTES as an array if hashes" do
     expect(Emarsys::FieldMapping::ATTRIBUTES).to be_a(Array)
-    Emarsys::FieldMapping::ATTRIBUTES.map{|elem| expect(elem).to be_a(Hash) }
+    expect(Emarsys::FieldMapping::ATTRIBUTES).to all(be_a(Hash))
+  end
+
+  describe '.attributes' do
+    describe 'backward-compatibility' do
+      it 'defines an array of hashes' do
+        expect(Emarsys::FieldMapping.attributes).to be_a(Array)
+        expect(Emarsys::FieldMapping.attributes).to all(be_a(Hash))
+      end
+
+      it 'returns the content of ATTRIBUTES by default' do
+        attributes_stub = double('ATTRIBUTES')
+        stub_const('Emarsys::FieldMapping::ATTRIBUTES', attributes_stub)
+
+        expect(Emarsys::FieldMapping.attributes).to eq(attributes_stub)
+      end
+    end
+  end
+
+  describe '.set_attributes' do
+    it 'redefines attributes' do
+      attributes = [
+        {:id => 101,   :identifier => 'foo', :name => 'Foo'},
+        {:id => 102,   :identifier => 'bar', :name => 'Bar'}
+      ]
+
+      Emarsys::FieldMapping.set_attributes(attributes)
+      expect(Emarsys::FieldMapping.attributes).to match_array(attributes)
+    end
+
+    it 'turns off use of default-predefined ATTRIBUTES' do
+      attributes_stub = double('ATTRIBUTES')
+      allow(attributes_stub).to receive(:<<).and_return(attributes_stub)
+
+      stub_const('Emarsys::FieldMapping::ATTRIBUTES', attributes_stub)
+
+      mapping_to_be_added = {
+        id: 2000, identifier: 'foo', name: 'Foo'
+      }
+
+      attributes = [
+        {:id => 101,   :identifier => 'foo', :name => 'Foo'},
+        {:id => 102,   :identifier => 'bar', :name => 'Bar'}
+      ]
+
+      Emarsys::FieldMapping.set_attributes(attributes)
+      Emarsys::FieldMapping::ATTRIBUTES << mapping_to_be_added
+
+      expect(Emarsys::FieldMapping.attributes).to match_array(attributes)
+    end
+  end
+
+  describe '.add_attributes' do
+    it "merges attributes" do
+      attributes = [
+        {:id => 101,   :identifier => 'foo', :name => 'Foo'},
+        {:id => 102,   :identifier => 'bar', :name => 'Bar'}
+      ]
+      Emarsys::FieldMapping.add_attributes(attributes)
+      expect(Emarsys::FieldMapping.attributes).to include(attributes[0], attributes[1])
+    end
   end
 
 end

--- a/spec/emarsys/params_converter_spec.rb
+++ b/spec/emarsys/params_converter_spec.rb
@@ -9,7 +9,10 @@ describe Emarsys::ParamsConverter do
       {:id => 1,   :identifier => 'first_name', :name => 'First Name'},
       {:id => 2,   :identifier => 'last_name',  :name => 'Last Name'},
     ]
-    stub_const("Emarsys::FieldMapping::ATTRIBUTES", attributes)
+
+    allow(Emarsys::FieldMapping).to receive(:attributes).and_return(
+      attributes
+    )
   end
 
   describe 'with attributes' do


### PR DESCRIPTION
Hi,

This is based off of the work great work of @my-kel, but with added backward-compatibility for the current behaviour of re-mapping and adding of mappings.

Resetting the mapping using `.set_attributes` now allows for total reset of the mappings and prevents further use of the default `ATTRIBUTES` mappings. `.add_attributes` still merges in a shallow copy of the `ATTRIBUTES`, unless a total reset via .set_attributes has been performed.

Thank you!