### PR TITLE
Add 'query' support to Contact data object

### DIFF
--- a/lib/emarsys/data_objects/contact.rb
+++ b/lib/emarsys/data_objects/contact.rb
@@ -119,6 +119,19 @@ module Emarsys
         post account, "contact/getdata", {'keyId' => key_id, 'keyValues' => key_values, 'fields' => fields}
       end
 
+      # Query contacts by custom
+      #
+      # @param key_id [Integer, String] The key used to query
+      # @param key_value [String] Value of internal id field
+      # @param return_value [Integer, String] Value of internal id field
+      # @return [Hash] result data
+      # @example
+      #   Emarsys::Contact.query('3', 'john.doe@example.com', 'uid')
+      #
+      def query(key_id:, key_value:, return_value: , account: nil)
+        get account, "contact/query", { key_id => key_value, 'return' => return_value}
+      end
+
       # Exports the selected fields of contacts whoch registered in the specified time range
       #
       # @param params [hash] hash of parameters according to emarsys API

--- a/spec/emarsys/data_objects/contact_spec.rb
+++ b/spec/emarsys/data_objects/contact_spec.rb
@@ -98,7 +98,7 @@ describe Emarsys::Contact do
 
   describe ".query" do
     it "queries contact data based on search params" do
-      stub = stub_request(:get, "https://api.emarsys.net/api/v2/contact/query?3=jane.doe@example.com&return=email").to_return(standard_return_body)
+      stub = stub_request(:get, "https://api.emarsys.net/api/v2/contact/query/?3=jane.doe@example.com&return=email").to_return(standard_return_body)
       Emarsys::Contact.query(key_id: 3, key_value: 'jane.doe@example.com', return_value: 'email')
       expect(stub).to have_been_requested.once
     end

--- a/spec/emarsys/data_objects/contact_spec.rb
+++ b/spec/emarsys/data_objects/contact_spec.rb
@@ -96,6 +96,14 @@ describe Emarsys::Contact do
     end
   end
 
+  describe ".query" do
+    it "queries contact data based on search params" do
+      stub = stub_request(:get, "https://api.emarsys.net/api/v2/contact/query?3=jane.doe@example.com&return=email").to_return(standard_return_body)
+      Emarsys::Contact.query(key_id: 3, key_value: 'jane.doe@example.com', return_value: 'email')
+      expect(stub).to have_been_requested.once
+    end
+  end
+
   describe ".export_registrations" do
     it "requests contact data export based on parameters" do
       stub_params = {distribution_method: 'local', time_range: ["2013-01-01","2013-12-31"], contact_fields: [1,2,3]}


### PR DESCRIPTION
I've added a wrapper for the `contact/query` route to the Contact data object.

`.search` and `.emarsys_id` return an error (2010) when there are duplicates (mail address e.g.).

Please consider merging this feature. Let me know if can improve this PR.

Signed-off-by: Henning Vogt <git@henvo.de>