### PR TITLE
Use cache time during request headers generation

### DIFF
--- a/emarsys.gemspec
+++ b/emarsys.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", ">= 3.5.0"
   spec.add_development_dependency "webmock", "< 2.0"
+  spec.add_development_dependency "timecop"
 end

--- a/lib/emarsys/client.rb
+++ b/lib/emarsys/client.rb
@@ -34,7 +34,7 @@ module Emarsys
     end
 
     def header_created
-      Time.now.utc.iso8601
+      @header_created ||= Time.now.utc.iso8601
     end
 
     def calculated_digest

--- a/spec/emarsys/client_spec.rb
+++ b/spec/emarsys/client_spec.rb
@@ -83,6 +83,15 @@ describe Emarsys::Client do
       it 'uses current timestamp format' do
         expect(Emarsys::Client.new.header_created).to eq(Time.now.utc.iso8601)
       end
+
+      it 'only generates time once' do
+        client = Emarsys::Client.new
+        header_created = Timecop.travel(Time.now - 10) do
+          client.header_created
+        end
+
+        expect(client.header_created).to eq(header_created)
+      end
     end
 
     describe '#calculated_digest' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require 'emarsys'
 require 'rspec'
 require 'webmock/rspec'
+require 'timecop'
 
 WebMock.disable_net_connect!
 


### PR DESCRIPTION
This will solve the following issue: 
`HTTP-Code: 401, Emarsys-Code: 1 - Unauthorized Password is invalid`
This is happening right now because X-Wsse header is using different values for "Created" and the password digest. This happens because header_created value is not cached.