### PR TITLE
Explicitly require 'erb'

### DIFF
--- a/lib/emarsys.rb
+++ b/lib/emarsys.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require "base64"
+require 'erb'
 require 'json'
 require 'rest_client'
 require 'uri'


### PR DESCRIPTION
This should fix 'NameError: uninitialized constant #<Class:Emarsys::DataObject>::ERB'
that occurs in some Ruby runtimes or env configurations.