### PR TITLE
Improved the Contact.query method

### DIFF
--- a/lib/emarsys/data_objects/contact.rb
+++ b/lib/emarsys/data_objects/contact.rb
@@ -121,15 +121,27 @@ module Emarsys
 
       # Query contacts by custom
       #
-      # @param key_id [Integer, String] The key used to query
-      # @param key_value [String] Value of internal id field
       # @param return_value [Integer, String] Value of internal id field
+      # @param account [String] The account to use
+      # @param opts [Mixed] Further symbols to pass down to the request
       # @return [Hash] result data
       # @example
-      #   Emarsys::Contact.query('3', 'john.doe@example.com', 'uid')
-      #
-      def query(key_id:, key_value:, return_value: , account: nil)
-        get account, "contact/query", { key_id => key_value, 'return' => return_value}
+      #   # Get all emails from the emarsys account
+      #   Emarsys::Contact.query(return_value: 'email')
+      #   # Get the ID of the account with a specific email
+      #   Emarsys::Contact.query(key_id: '_email', key_value: 'john.doe@example.com', return_value: 'email')
+      #   Emarsys::Contact.query(key_id: 3, key_value: 'jane.doe@example.com', return_value: 'email')
+      def query(return_value:, account: nil, **opts)
+        if opts.key?(:key_id) && opts.key?(:key_value)
+          id, value = [opts.delete(:key_id), opts.delete(:key_value)]
+          opts["#{transform_key_id(id).to_s}"] = value
+        end
+
+        opts = opts.each_with_object({}) do |(key, val), memo|
+          memo[key.to_s] = val
+        end
+
+        get account, 'contact/query', opts.merge('return' => return_value)
       end
 
       # Exports the selected fields of contacts whoch registered in the specified time range

--- a/spec/emarsys/data_objects/contact_spec.rb
+++ b/spec/emarsys/data_objects/contact_spec.rb
@@ -102,6 +102,18 @@ describe Emarsys::Contact do
       Emarsys::Contact.query(key_id: 3, key_value: 'jane.doe@example.com', return_value: 'email')
       expect(stub).to have_been_requested.once
     end
+
+    it "transforms the key_id correctly to its id" do
+      stub = stub_request(:get, "https://api.emarsys.net/api/v2/contact/query/?3=jane.doe@example.com&return=email").to_return(standard_return_body)
+      Emarsys::Contact.query(key_id: '_email', key_value: 'jane.doe@example.com', return_value: 'email')
+      expect(stub).to have_been_requested.once
+    end
+
+    it "allows to get all contacts" do
+      stub = stub_request(:get, "https://api.emarsys.net/api/v2/contact/query/?return=email").to_return(standard_return_body)
+      Emarsys::Contact.query(return_value: 'email')
+      expect(stub).to have_been_requested.once
+    end
   end
 
   describe ".export_registrations" do


### PR DESCRIPTION
**- What is it good for**

This PR ships an enhanced `Contact.query` method which allows to query all contacts without requiring any filter. Furthermore it transforms the `key_id` and `key_value` when passed.

**- What I did**

I added the transformation of the passed `key_id` and the possibility to pass in custom filters. The YARD documentation was updated to reflect this with more examples and for the new usages specs were added.

**- A picture of a cute animal (not mandatory but encouraged)**

![images](https://user-images.githubusercontent.com/2496275/47513163-f0f68700-d87d-11e8-828d-df4b22ead68f.jpeg)