### PR TITLE
Add supported segment endpoints and remove the deprecated one

### DIFF
--- a/emarsys.gemspec
+++ b/emarsys.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "rest-client"
 
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "bundler", "~> 2.1.4"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", ">= 3.5.0"
   spec.add_development_dependency "webmock", "< 2.0"

--- a/emarsys.gemspec
+++ b/emarsys.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 2.1.4"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", ">= 3.5.0"
-  spec.add_development_dependency "webmock", "< 2.0"
+  spec.add_development_dependency "webmock", "~> 2.3.2"
   spec.add_development_dependency "timecop"
 end

--- a/lib/emarsys/data_objects/contact_list.rb
+++ b/lib/emarsys/data_objects/contact_list.rb
@@ -16,6 +16,14 @@ module Emarsys
         get account, 'contactlist', {}
       end
 
+      # List contacts in a contact list
+      # Reference: https://dev.emarsys.com/v2/contact-lists/list-contacts-in-a-contact-list
+      # 
+      # @param id [Integer] The contact list id
+      def contacts(id, account: nil)
+        get account, "contactlist/#{id}/", {}
+      end
+
       # Create a new contact list
       #
       # @param params [Hash] Contact list information to create

--- a/lib/emarsys/data_objects/segment.rb
+++ b/lib/emarsys/data_objects/segment.rb
@@ -28,6 +28,24 @@ module Emarsys
         path = "filter/#{id}/contacts"
         get account, path, limit: limit, offset: offset
       end
+
+      # Run a Segment for Multiple Contacts
+      # Reference: https://dev.emarsys.com/v2/segments/run-a-contact-segment-batch
+      #
+      # @param id [Integer] the id of the segment
+      def run(id, account: nil)
+        path = "filter/#{id}/runs"
+        post account, path, {}
+      end
+
+      # Poll the Status of a Segment Run for Multiple Contacts
+      # Reference: https://dev.emarsys.com/v2/segments/poll-the-status-of-a-segment-run-for-multiple-contacts
+      #
+      # @param run_id [Integer] the id of the segment run, @see #run
+      def status(run_id, account: nil)
+        path = "filter/runs/#{run_id}"
+        get account, path, {}
+      end
     end
   end
 

--- a/lib/emarsys/data_objects/segment.rb
+++ b/lib/emarsys/data_objects/segment.rb
@@ -28,7 +28,7 @@ module Emarsys
       # Poll the Status of a Segment Run for Multiple Contacts
       # Reference: https://dev.emarsys.com/v2/segments/poll-the-status-of-a-segment-run-for-multiple-contacts
       #
-      # @param run_id [Integer] the id of the segment run, @see #run
+      # @param run_id [String] the id of the segment run, @see #run
       def status(run_id, account: nil)
         path = "filter/runs/#{run_id}"
         get account, path, {}

--- a/lib/emarsys/data_objects/segment.rb
+++ b/lib/emarsys/data_objects/segment.rb
@@ -16,19 +16,6 @@ module Emarsys
         get account, 'filter', {}
       end
 
-      # List ids of contacts in a segment.
-      # Raises Emarsys::SegmentIsEvaluated if the segment is being currently evaluated.
-      # Reference: https://dev.emarsys.com/v2/response-codes/http-202-errors
-      # The `limit` param is required by this endpoint although it is marked as optional in the API v2 doc.
-      #
-      # @param id [Integer] the id of the segment
-      # @param limit [Integer] the maximum number of records to return
-      # @param offset [Integer] optional offset value for pagination
-      def contacts(id, limit:, offset: 0, account: nil)
-        path = "filter/#{id}/contacts"
-        get account, path, limit: limit, offset: offset
-      end
-
       # Run a Segment for Multiple Contacts
       # Reference: https://dev.emarsys.com/v2/segments/run-a-contact-segment-batch
       #

--- a/lib/emarsys/error.rb
+++ b/lib/emarsys/error.rb
@@ -28,10 +28,6 @@ module Emarsys
   # Raised when Emarsys returns a 500 HTTP status code
   class InternalServerError < Error; end
 
-  # Raised when Emarsys returns a 202 HTTP status code with 10001 Reply Code
-  # https://dev.emarsys.com/v2/response-codes/http-202-errors
-  class SegmentIsEvaluated < Error; end
-
   class AccountNotConfigured < StandardError; end
 
   class AccountRequired < StandardError; end

--- a/lib/emarsys/response.rb
+++ b/lib/emarsys/response.rb
@@ -21,8 +21,6 @@ module Emarsys
           raise Emarsys::Unauthorized.new(code, text, status)
         elsif status == 429
           raise Emarsys::TooManyRequests.new(code, text, status)
-        elsif status == 202 && code == 10001
-          raise Emarsys::SegmentIsEvaluated.new(code, text, status) 
         else
           raise Emarsys::BadRequest.new(code, text, status)
         end

--- a/spec/emarsys/data_objects/contact_list_spec.rb
+++ b/spec/emarsys/data_objects/contact_list_spec.rb
@@ -8,4 +8,11 @@ describe Emarsys::ContactList do
       ).to have_been_requested.once
     end
   end
+  describe ".contacts" do
+    it "requests all contacts in the given contact list" do
+      expect(
+        stub_get("contactlist/123/") { Emarsys::ContactList.contacts(123) }
+      ).to have_been_requested.once
+    end
+  end
 end

--- a/spec/emarsys/data_objects/segment_spec.rb
+++ b/spec/emarsys/data_objects/segment_spec.rb
@@ -7,13 +7,6 @@ describe Emarsys::Segment do
         stub_get("filter") { Emarsys::Segment.collection }
       ).to have_been_requested.once
     end
-    describe ".contacts" do
-      it "requests contact data for a given segment" do
-        stub = stub_request(:get, "https://api.emarsys.net/api/v2/filter/123/contacts/?limit=2000&offset=0").to_return(standard_return_body)
-        Emarsys::Segment.contacts(123, limit: 2000)
-        expect(stub).to have_been_requested.once
-      end
-    end
     describe ".run" do
       it "requests a run for a segment for multiple contacts" do
         expect(

--- a/spec/emarsys/data_objects/segment_spec.rb
+++ b/spec/emarsys/data_objects/segment_spec.rb
@@ -17,7 +17,7 @@ describe Emarsys::Segment do
     describe ".status" do
       it "requests the status of the given segment run" do
         expect(
-          stub_get("filter/runs/333") { Emarsys::Segment.status(333) }
+          stub_get("filter/runs/foo-333-bar") { Emarsys::Segment.status('foo-333-bar') }
         ).to have_been_requested.once
       end
     end

--- a/spec/emarsys/data_objects/segment_spec.rb
+++ b/spec/emarsys/data_objects/segment_spec.rb
@@ -14,5 +14,19 @@ describe Emarsys::Segment do
         expect(stub).to have_been_requested.once
       end
     end
+    describe ".run" do
+      it "requests a run for a segment for multiple contacts" do
+        expect(
+          stub_post("filter/123/runs") { Emarsys::Segment.run(123) }
+        ).to have_been_requested.once
+      end
+    end
+    describe ".status" do
+      it "requests the status of the given segment run" do
+        expect(
+          stub_get("filter/runs/333") { Emarsys::Segment.status(333) }
+        ).to have_been_requested.once
+      end
+    end
   end
 end

--- a/spec/emarsys/response_spec.rb
+++ b/spec/emarsys/response_spec.rb
@@ -78,14 +78,6 @@ describe Emarsys::Response do
       allow(fake_response).to receive(:code).and_return(429)
       expect{response}.to raise_error(Emarsys::TooManyRequests)
     end
-
-    context 'with Reply Code 10001' do
-      let(:reply_code) { 10001 }
-      it "raises SegmentIsEvaluated error if http-status i 202" do
-        allow(fake_response).to receive(:code).and_return(202)
-        expect{response}.to raise_error(Emarsys::SegmentIsEvaluated)
-      end
-    end
   end
 
 end


### PR DESCRIPTION
The `List Contacts in a Segment` endpoint is [deprecated and soon will be removed](https://dev.emarsys.com/v2/segments/list-contacts-in-a-segment). This PR removes the code related to that endpoint and add support for other endpoints that can be used together to fetch contacts in a segment.

