### PR TITLE
Fix add attributes method

### DIFF
--- a/lib/emarsys/field_mapping.rb
+++ b/lib/emarsys/field_mapping.rb
@@ -65,7 +65,7 @@ module Emarsys::FieldMapping
   end
 
   def self.add_attributes(attrs)
-    @custom_attributes.concat([attrs].flatten)
+    attributes.concat([attrs].flatten)
   end
 
   def self.excluded_default_attributes?

--- a/spec/emarsys/field_mapping_spec.rb
+++ b/spec/emarsys/field_mapping_spec.rb
@@ -66,8 +66,15 @@ describe Emarsys::FieldMapping do
         {:id => 101,   :identifier => 'foo', :name => 'Foo'},
         {:id => 102,   :identifier => 'bar', :name => 'Bar'}
       ]
-      Emarsys::FieldMapping.add_attributes(attributes)
-      expect(Emarsys::FieldMapping.attributes).to include(attributes[0], attributes[1])
+
+      stub_const('Emarsys::FieldMapping::ATTRIBUTES', attributes)
+
+      mapping_to_be_added = {
+        id: 2000, identifier: 'baz', name: 'Baz'
+      }
+
+      Emarsys::FieldMapping.add_attributes(mapping_to_be_added)
+      expect(Emarsys::FieldMapping.attributes).to include(attributes[0], attributes[1], mapping_to_be_added)
     end
   end
 


### PR DESCRIPTION
Calling `add_attributes` without `set_attributes` first would return a `NoMethodError: undefined method 'concat' for nil:NilClass` error because of a nil `@custom_attributes`. This can be seen by running the spec in isolation

```shell
rspec spec/emarsys/field_mapping_spec.rb:63
```