### PR TITLE
Fix CSV data export

### DIFF
--- a/lib/emarsys/response.rb
+++ b/lib/emarsys/response.rb
@@ -4,7 +4,7 @@ module Emarsys
     attr_accessor :code, :text, :data, :status
 
     def initialize(response)
-      if response.headers[:content_type] == 'text/csv'
+      if response.headers[:content_type]&.start_with?('text/csv')
         self.code = 0
         self.data = response.body
       else

--- a/spec/emarsys/response_spec.rb
+++ b/spec/emarsys/response_spec.rb
@@ -22,7 +22,7 @@ describe Emarsys::Response do
 
     module CSV
       def headers
-        {:content_type => 'text/csv'}
+        {:content_type => 'text/csv;charset=UTF-8'}
       end
     end
   end


### PR DESCRIPTION
Getting the data exported as a CSV would throw an error because the header check condition doesn't match and it gets processed as a JSON. This is because the content type is `text/csv;charset=UTF-8` instead of `text/csv`. https://dev.emarsys.com/v2/contact-and-email-data/export-responses

I replaced the condition with a `start_with?` just in case there are endpoints I'm not aware of that actually return `text/csv`.